### PR TITLE
Explicando melhor a conexão entre lores

### DIFF
--- a/Form.md
+++ b/Form.md
@@ -8,5 +8,5 @@
 - Bot pra pegar quem são os adms atuais (talvez?)
 - Linkagem de conta do mine com o discord (tbm talvez?)
 - Pesquisa de lores
-- Conexões entre lores
+- Conexões entre lores (partes do texto mostram sua relação com outro(s) personagem(s)) 
 - Biblioteca publica de lores (se for interessante)


### PR DESCRIPTION
A conexão entre lores deveria não só ser destacada na parte do texto que se relaciona a outro(s) personagem(s), mas também deveria mostrar o contexto e como são relacionadas, com explicações e consequências dessa conexão